### PR TITLE
Toggle to apply User's Regex scripts to rewrite

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ import {
     generateRaw,
 } from "../../../../script.js";
 import { extension_settings, getContext } from "../../../extensions.js";
+import { getRegexedString, regex_placement } from '../../regex/engine.js'; // Import from built-in regex extension
 
 const extensionName = "rewrite-extension";
 const extensionFolderPath = `scripts/extensions/third-party/${extensionName}`;
@@ -58,6 +59,7 @@ Sure, here is only the rewritten text without any comments: `,
     showShorten: true,
     showExpand: true,
     showDelete: true,
+    applyRegexOnRewrite: true, // New setting to control regex application
 };
 
 let rewriteMenu = null;
@@ -105,6 +107,7 @@ function loadSettings() {
     $("#show_shorten").prop('checked', getSetting('showShorten', defaultSettings.showShorten));
     $("#show_expand").prop('checked', getSetting('showExpand', defaultSettings.showExpand));
     $("#show_delete").prop('checked', getSetting('showDelete', defaultSettings.showDelete));
+    $("#apply_regex_on_rewrite").prop('checked', getSetting('applyRegexOnRewrite', defaultSettings.applyRegexOnRewrite)); // Load new setting
 
     // Update the UI based on loaded settings
     updateModelSettings();
@@ -140,6 +143,7 @@ function saveSettings() {
         showShorten: $("#show_shorten").is(':checked'),
         showExpand: $("#show_expand").is(':checked'),
         showDelete: $("#show_delete").is(':checked'),
+        applyRegexOnRewrite: $("#apply_regex_on_rewrite").is(':checked'), // Save new setting
     };
 
     // Ensure all settings have a value, using defaults if necessary
@@ -223,6 +227,7 @@ jQuery(async () => {
     $("#remove_prefix, #remove_suffix").on("change", saveSettings);
     $("#override_max_tokens").on("change", saveSettings);
     $("#show_rewrite, #show_shorten, #show_expand, #show_delete").on("change", saveSettings);
+    $("#apply_regex_on_rewrite").on("change", saveSettings); // Add listener for new checkbox
 
     $("#rewrite_extension_model_select").on("change", () => {
         updateModelSettings();
@@ -1229,10 +1234,16 @@ async function saveRewrittenText(mesId, swipeId, fullMessage, startOffset, endOf
         newText = newText.slice(0, -removeSuffix.length);
     }
 
-    // Create the new message with the rewritten section
+    // Apply AI Output regex scripts if setting is enabled
+    let processedText = newText; // Default to original newText
+    if (extension_settings[extensionName].applyRegexOnRewrite) {
+        processedText = getRegexedString(newText, regex_placement.AI_OUTPUT);
+    }
+
+    // Create the new message with the rewritten and potentially processed section
     const newMessage =
         fullMessage.substring(0, startOffset) +
-        newText +
+        processedText + // Use the processed text here
         fullMessage.substring(endOffset);
 
     // Save the change to the history

--- a/rewrite_settings.html
+++ b/rewrite_settings.html
@@ -76,6 +76,14 @@
 
             <div class="rewrite-extension_block flex-container checkbox-container">
                 <div class="checkbox-label-group">
+                    <input type="checkbox" id="apply_regex_on_rewrite" class="checkbox">
+                    <label for="apply_regex_on_rewrite">Apply Regex on Rewrite</label>
+                </div>
+                <span class="tooltip-icon fa-solid fa-circle-question" data-tooltip="If checked, applies configured AI Output regex scripts to the rewritten text."></span>
+            </div>
+
+            <div class="rewrite-extension_block flex-container checkbox-container">
+                <div class="checkbox-label-group">
                     <input type="checkbox" id="use_dynamic_tokens" class="checkbox">
                     <label for="use_dynamic_tokens">Use Dynamic Token Calculation</label>
                 </div>


### PR DESCRIPTION
Hey, I really like how this extension works, so I wanted to add a few things.

This pull request adds two things:
- Support for Regex scripts from the SillyTavern core extension being applied to the AI's output upon rewrite.
- A toggle for users to enable or disable the application of said scripts.

This generally expands the use cases to all the various things you can normally do with Regex scripts, but in particular makes it so that if users wish to use a reasoning model or implement a chain of thought prompt in their rewrite preset, they can apply Regex to parse out the <think> tags and preserve just the final text.