### PR TITLE
Adjust raw text offsets to include surrounding markdown for italics and bold

### DIFF
--- a/index.js
+++ b/index.js
@@ -641,31 +641,49 @@ function getSelectedTextInfo(mesId, mesDiv) {
     let rawStartOffset = mapping.formattedToRaw(startOffset);
     let rawEndOffset = mapping.formattedToRaw(endOffset);
 
-    // Heuristic: Adjust offsets to include surrounding markdown if selection seems to abut it
-    // Check for italics (*)
-    if (rawStartOffset > 0 && rawEndOffset < fullMessage.length &&
-        fullMessage[rawStartOffset - 1] === '*' && fullMessage[rawEndOffset] === '*') {
-        // Avoid expanding if it looks like bold/bold-italics boundary
-        const prevChar = rawStartOffset > 1 ? fullMessage[rawStartOffset - 2] : null;
-        const nextChar = rawEndOffset + 1 < fullMessage.length ? fullMessage[rawEndOffset + 1] : null;
-        if (prevChar !== '*' && nextChar !== '*') {
-            rawStartOffset--;
-            rawEndOffset++;
-        }
-    }
-    // Check for bold (**) - ensure we don't double-adjust if italics check already expanded
-    else if (rawStartOffset > 1 && rawEndOffset < fullMessage.length - 1 &&
-             fullMessage.substring(rawStartOffset - 2, rawStartOffset) === '**' &&
-             fullMessage.substring(rawEndOffset, rawEndOffset + 2) === '**') {
-        // Avoid expanding if it looks like bold-italics boundary
+    // Heuristic: Adjust offsets independently to include abutting markdown characters
+
+    // Check start offset
+    if (rawStartOffset > 1 && fullMessage.substring(rawStartOffset - 2, rawStartOffset) === '**') {
+        // Check for *** boundary to avoid over-adjusting
         const prevChar = rawStartOffset > 2 ? fullMessage[rawStartOffset - 3] : null;
-        const nextChar = rawEndOffset + 2 < fullMessage.length ? fullMessage[rawEndOffset + 2] : null;
-        if (prevChar !== '*' && nextChar !== '*') {
-            rawStartOffset -= 2;
-            rawEndOffset += 2;
+        if (prevChar !== '*') {
+             rawStartOffset -= 2; // Adjust for bold start
+        } else if (rawStartOffset > 0 && fullMessage[rawStartOffset - 1] === '*') {
+             // Handle *** case specifically or just adjust for * if prev wasn't *
+             const prevPrevChar = rawStartOffset > 1 ? fullMessage[rawStartOffset - 2] : null;
+             if (prevPrevChar !== '*') {
+                 rawStartOffset--; // Adjust for italics start if not part of ** or ***
+             }
         }
+    } else if (rawStartOffset > 0 && fullMessage[rawStartOffset - 1] === '*') {
+         // Check for ** or *** boundary to avoid over-adjusting
+         const prevChar = rawStartOffset > 1 ? fullMessage[rawStartOffset - 2] : null;
+         if (prevChar !== '*') {
+             rawStartOffset--; // Adjust for italics start
+         }
     }
-    // Note: This doesn't handle ***bold italics*** or nested cases perfectly, but covers common scenarios.
+
+    // Check end offset
+    if (rawEndOffset < fullMessage.length - 1 && fullMessage.substring(rawEndOffset, rawEndOffset + 2) === '**') {
+        // Check for *** boundary to avoid over-adjusting
+        const nextChar = rawEndOffset + 2 < fullMessage.length ? fullMessage[rawEndOffset + 2] : null;
+        if (nextChar !== '*') {
+            rawEndOffset += 2; // Adjust for bold end
+        } else if (rawEndOffset < fullMessage.length && fullMessage[rawEndOffset] === '*') {
+             // Handle *** case specifically or just adjust for * if next wasn't *
+             const nextNextChar = rawEndOffset + 1 < fullMessage.length ? fullMessage[rawEndOffset + 1] : null;
+             if (nextNextChar !== '*') {
+                 rawEndOffset++; // Adjust for italics end if not part of ** or ***
+             }
+        }
+    } else if (rawEndOffset < fullMessage.length && fullMessage[rawEndOffset] === '*') {
+         // Check for ** or *** boundary to avoid over-adjusting
+         const nextChar = rawEndOffset + 1 < fullMessage.length ? fullMessage[rawEndOffset + 1] : null;
+         if (nextChar !== '*') {
+             rawEndOffset++; // Adjust for italics end
+         }
+    }
 
     // Get the selected raw text using potentially adjusted offsets
     const selectedRawText = fullMessage.substring(rawStartOffset, rawEndOffset);


### PR DESCRIPTION
This pull request modifies the raw text offsets to include asterisks surrounding the start and end position of the highlighted text for replacement.

Before this behavior, rewritten text would be inserted into the message without replacing any asterisks surrounding the highlighted area. This meant that if model output included asterisks surrounding the rewritten text, the asterisks would be duplicated, breaking the formatting.

 For example:

\*Example text\* -> Rewrite Process -> Insertion -> \*\*Rewritten text\*\*

This pull request includes the surrounding asterisks in the start and end offset so that the replacement process also replaces any existing asterisks.